### PR TITLE
Filter for Audio Extensions & Copy Directory to .hydrogen/data/drumkits

### DIFF
--- a/src/com/hydroLibCreator/action/Creator.java
+++ b/src/com/hydroLibCreator/action/Creator.java
@@ -7,6 +7,10 @@ package com.hydroLibCreator.action;
 import com.hydroLibCreator.exception.ApplicationException;
 import com.hydroLibCreator.model.AudioLibrary;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.FileFileFilter;
+import org.apache.commons.io.filefilter.FileFilterUtils;
+import org.apache.commons.io.filefilter.IOFileFilter;
+import org.apache.commons.io.filefilter.SuffixFileFilter;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -18,11 +22,9 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.*;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FilenameFilter;
-import java.io.IOException;
+import java.io.*;
 import java.util.Arrays;
+import java.util.List;
 
 
 public class Creator {
@@ -79,7 +81,7 @@ public class Creator {
 
         try {
 
-            FileUtils.copyDirectory(sourceDir, destinationDir);
+            FileUtils.copyDirectory(sourceDir, destinationDir, this.audioExtensionFilter());
 
         } catch (IOException e) {
             e.printStackTrace();
@@ -339,4 +341,10 @@ public class Creator {
         return instrumentList;
     }
 
+    private FileFilter audioExtensionFilter() {
+        List audioFileExtensions = Arrays.asList(".wav", ".flac" );
+        IOFileFilter audioFileSuffixFilter = new SuffixFileFilter(audioFileExtensions);
+
+        return FileFilterUtils.andFileFilter(FileFileFilter.FILE, audioFileSuffixFilter);
+    }
 }

--- a/src/com/hydroLibCreator/action/Creator.java
+++ b/src/com/hydroLibCreator/action/Creator.java
@@ -41,7 +41,7 @@ public class Creator {
         if(!sourceDir.exists())
             throw new ApplicationException("No such directory exists", "please make sure you have the correct path to the library");
 
-        destinationDir = new File(audioLibrary.getDirectorypath()+"/"+sourceDir.getName()+"_HLIB");
+        destinationDir = this.newDestinationDir(sourceDir.getName());
         this.destinationPath = destinationDir.getPath();
 
         audioLibrary.setNewLibPath(this.destinationPath);
@@ -339,4 +339,12 @@ public class Creator {
         return instrumentList;
     }
 
+    private File newDestinationDir(String drumKitName) {
+        String destinationDirectory = System.getProperty("user.home")
+            .concat("/.hydrogen/data/drumkits/")
+            .concat(drumKitName)
+            .concat("_HLIB");
+
+        return new File(destinationDirectory);
+    }
 }

--- a/src/com/hydroLibCreator/action/Creator.java
+++ b/src/com/hydroLibCreator/action/Creator.java
@@ -25,6 +25,7 @@ import javax.xml.transform.stream.StreamResult;
 import java.io.*;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 public class Creator {
@@ -32,7 +33,7 @@ public class Creator {
     private String destinationPath;
     private File sourceDir;
     private File destinationDir;
-    private String[] audioFileslist;
+    private List<String> audioFileslist;
 
     private AudioLibrary audioLibrary;
 
@@ -60,19 +61,14 @@ public class Creator {
 
     private void setSortedAudioFileslist(){
 
-        this.audioFileslist = sourceDir.list();
+        this.audioFileslist = FileUtils.listFiles(sourceDir, this.audioExtensionFilter(), null)
+            .stream()
+            .map(File::getName)
+            .sorted()
+            .collect(Collectors.toList());
 
-        FilenameFilter filter = new FilenameFilter() {
-            @Override
-            public boolean accept(File dir, String name) {
-                return false;
-            }
-        };
-
-        if (audioFileslist == null||audioFileslist.length==-1)
+        if (audioFileslist == null || audioFileslist.isEmpty())
             throw new ApplicationException("Missing Audio Files Exception", "Please make sure your directory has audio files");
-
-        Arrays.sort(audioFileslist);
 
     }
 
@@ -341,11 +337,9 @@ public class Creator {
         return instrumentList;
     }
 
-    private FileFilter audioExtensionFilter() {
+    private IOFileFilter audioExtensionFilter() {
         List audioFileExtensions = Arrays.asList(".wav", ".flac");
-        IOFileFilter audioFileSuffixFilter = new SuffixFileFilter(audioFileExtensions);
-
-        return FileFilterUtils.andFileFilter(FileFileFilter.FILE, audioFileSuffixFilter);
+        return new SuffixFileFilter(audioFileExtensions);
     }
 
     private File newDestinationDir(String drumKitName) {


### PR DESCRIPTION
This starts to get basic functionality for the missing features mentioned in the readme.

Another iteration to this may handle the case when a drum kit already exists in the user's library, prompting the user to cancel or overwrite the kit.